### PR TITLE
Fix device dashboard status consistency and chart empty states

### DIFF
--- a/mediasoup-server/src/room-manager.ts
+++ b/mediasoup-server/src/room-manager.ts
@@ -8,6 +8,7 @@ export interface Room {
     consumers: Map<string, Consumer>; // Viewers
     transports: Map<string, WebRtcTransport>;
     recorder?: Recorder;
+    recordingTimer?: NodeJS.Timeout;
 }
 
 export class RoomManager {
@@ -35,6 +36,10 @@ export class RoomManager {
         if (room) {
             // Close all transports
             room.transports.forEach(transport => transport.close());
+            if (room.recordingTimer) {
+                clearInterval(room.recordingTimer);
+                room.recordingTimer = undefined;
+            }
 
             // Close producer
             if (room.producer) {

--- a/mediasoup-server/src/server.ts
+++ b/mediasoup-server/src/server.ts
@@ -28,6 +28,21 @@ const io = new SocketIOServer(httpServer, {
 const mediasoupManager = new MediasoupManager();
 const roomManager = new RoomManager();
 
+async function restartRoomRecorder(roomId: string): Promise<void> {
+    const room = roomManager.getRoom(roomId);
+    if (!room || !room.producer) {
+        throw new Error('Room or producer not found');
+    }
+
+    const recorder = new Recorder(
+        room.router,
+        roomId,
+        room.producer.id,
+        room.producer.kind === 'audio'
+    );
+    await recorder.start();
+    room.recorder = recorder;
+}
 // Health check
 app.get('/health', (req, res) => {
     res.json({
@@ -253,16 +268,7 @@ io.on('connection', (socket) => {
                 throw new Error('Recording already in progress');
             }
 
-            // Initialize recorder
-            const recorder = new Recorder(
-                room.router,
-                roomId,
-                room.producer.id,
-                room.producer.kind === 'audio'
-            );
-
-            await recorder.start();
-            room.recorder = recorder;
+            await restartRoomRecorder(roomId);
 
             callback({ success: true });
         } catch (error: any) {

--- a/web/app/components/DeviceCharts.tsx
+++ b/web/app/components/DeviceCharts.tsx
@@ -28,6 +28,11 @@ export default function DeviceCharts({ deviceId }: DeviceChartsProps) {
     const hasAnyValue = (rows: any[], key: string) =>
         rows.some((row) => typeof row?.[key] === "number" && Number.isFinite(row[key]))
 
+    const toNumberOrNull = (value: unknown): number | null => {
+        const parsed = Number(value)
+        return Number.isFinite(parsed) ? parsed : null
+    }
+
     useEffect(() => {
         const fetchData = async () => {
             setLoading(true)
@@ -47,8 +52,12 @@ export default function DeviceCharts({ deviceId }: DeviceChartsProps) {
                 const stats = await getTelemetryStats(deviceId, start.toISOString(), end, granularity)
                 const normalized = (stats || []).map((row: any) => ({
                     ...row,
-                    thermalLevel: Number.isFinite(Number(row?.thermalLevel)) ? Number(row.thermalLevel) : 0,
-                    batteryTempC: Number.isFinite(Number(row?.batteryTempC)) ? Number(row.batteryTempC) : 0,
+                    cpu: toNumberOrNull(row?.cpu),
+                    ram: toNumberOrNull(row?.ram),
+                    battery: toNumberOrNull(row?.battery),
+                    diskFree: toNumberOrNull(row?.diskFree),
+                    batteryTempC: toNumberOrNull(row?.batteryTempC),
+                    thermalLevel: toNumberOrNull(row?.thermalLevel),
                 }))
                 setData(normalized)
             } catch (error) {
@@ -77,7 +86,7 @@ export default function DeviceCharts({ deviceId }: DeviceChartsProps) {
                     <p className="text-slate-300 text-xs mb-2">{format(new Date(label), "d MMM, HH:mm", { locale: es })}</p>
                     {payload.map((p: any) => (
                         <p key={p.name} className="text-sm font-medium" style={{ color: p.color }}>
-                            {p.name}: {p.value.toFixed(1)}{p.unit}
+                            {p.name}: {typeof p.value === 'number' ? p.value.toFixed(1) : 'N/A'}{p.unit || ''}
                         </p>
                     ))}
                 </div>
@@ -154,21 +163,27 @@ export default function DeviceCharts({ deviceId }: DeviceChartsProps) {
                             RAM
                         </h3>
                         <div className="h-56">
-                            <ResponsiveContainer width="100%" height="100%">
-                                <AreaChart data={data}>
-                                    <defs>
-                                        <linearGradient id="colorRam" x1="0" y1="0" x2="0" y2="1">
-                                            <stop offset="5%" stopColor="#34d399" stopOpacity={0.3} />
-                                            <stop offset="95%" stopColor="#34d399" stopOpacity={0} />
-                                        </linearGradient>
-                                    </defs>
-                                    <CartesianGrid strokeDasharray="3 3" stroke="#334155" vertical={false} />
-                                    <XAxis dataKey="timestamp" tickFormatter={formatDate} stroke="#64748b" tick={{ fontSize: 10 }} tickMargin={10} />
-                                    <YAxis stroke="#64748b" tick={{ fontSize: 10 }} domain={[0, 100]} unit="%" />
-                                    <Tooltip content={<CustomTooltip />} />
-                                    <Area type="monotone" dataKey="ram" name="RAM" stroke="#34d399" fillOpacity={1} fill="url(#colorRam)" unit="%" strokeWidth={2} />
-                                </AreaChart>
-                            </ResponsiveContainer>
+                            {hasAnyValue(data, "ram") ? (
+                                <ResponsiveContainer width="100%" height="100%">
+                                    <AreaChart data={data}>
+                                        <defs>
+                                            <linearGradient id="colorRam" x1="0" y1="0" x2="0" y2="1">
+                                                <stop offset="5%" stopColor="#34d399" stopOpacity={0.3} />
+                                                <stop offset="95%" stopColor="#34d399" stopOpacity={0} />
+                                            </linearGradient>
+                                        </defs>
+                                        <CartesianGrid strokeDasharray="3 3" stroke="#334155" vertical={false} />
+                                        <XAxis dataKey="timestamp" tickFormatter={formatDate} stroke="#64748b" tick={{ fontSize: 10 }} tickMargin={10} />
+                                        <YAxis stroke="#64748b" tick={{ fontSize: 10 }} domain={[0, 100]} unit="%" />
+                                        <Tooltip content={<CustomTooltip />} />
+                                        <Area type="monotone" dataKey="ram" name="RAM" stroke="#34d399" fillOpacity={1} fill="url(#colorRam)" unit="%" strokeWidth={2} />
+                                    </AreaChart>
+                                </ResponsiveContainer>
+                            ) : (
+                                <div className="h-full flex items-center justify-center text-xs text-slate-500">
+                                    Sin dato de RAM
+                                </div>
+                            )}
                         </div>
                     </div>
 
@@ -210,15 +225,21 @@ export default function DeviceCharts({ deviceId }: DeviceChartsProps) {
                             Temperatura de Batería (°C)
                         </h3>
                         <div className="h-56">
-                            <ResponsiveContainer width="100%" height="100%">
-                                <LineChart data={data}>
-                                    <CartesianGrid strokeDasharray="3 3" stroke="#334155" vertical={false} />
-                                    <XAxis dataKey="timestamp" tickFormatter={formatDate} stroke="#64748b" tick={{ fontSize: 10 }} tickMargin={10} />
-                                    <YAxis stroke="#64748b" tick={{ fontSize: 10 }} unit="°C" />
-                                    <Tooltip content={<CustomTooltip />} />
-                                    <Line type="monotone" dataKey="batteryTempC" name="Temp batería" stroke="#f97316" dot={false} unit="°C" strokeWidth={2} />
-                                </LineChart>
-                            </ResponsiveContainer>
+                            {hasAnyValue(data, "batteryTempC") ? (
+                                <ResponsiveContainer width="100%" height="100%">
+                                    <LineChart data={data}>
+                                        <CartesianGrid strokeDasharray="3 3" stroke="#334155" vertical={false} />
+                                        <XAxis dataKey="timestamp" tickFormatter={formatDate} stroke="#64748b" tick={{ fontSize: 10 }} tickMargin={10} />
+                                        <YAxis stroke="#64748b" tick={{ fontSize: 10 }} unit="°C" />
+                                        <Tooltip content={<CustomTooltip />} />
+                                        <Line type="monotone" dataKey="batteryTempC" name="Temp batería" stroke="#f97316" dot={false} unit="°C" strokeWidth={2} />
+                                    </LineChart>
+                                </ResponsiveContainer>
+                            ) : (
+                                <div className="h-full flex items-center justify-center text-xs text-slate-500">
+                                    Sin dato de temperatura
+                                </div>
+                            )}
                         </div>
                     </div>
 
@@ -229,15 +250,21 @@ export default function DeviceCharts({ deviceId }: DeviceChartsProps) {
                             Severidad Térmica
                         </h3>
                         <div className="h-56">
-                            <ResponsiveContainer width="100%" height="100%">
-                                <LineChart data={data}>
-                                    <CartesianGrid strokeDasharray="3 3" stroke="#334155" vertical={false} />
-                                    <XAxis dataKey="timestamp" tickFormatter={formatDate} stroke="#64748b" tick={{ fontSize: 10 }} tickMargin={10} />
-                                    <YAxis stroke="#64748b" tick={{ fontSize: 10 }} domain={[0, 6]} />
-                                    <Tooltip content={<CustomTooltip />} />
-                                    <Line type="monotone" dataKey="thermalLevel" name="Thermal" stroke="#ef4444" dot={false} strokeWidth={2} />
-                                </LineChart>
-                            </ResponsiveContainer>
+                            {hasAnyValue(data, "thermalLevel") ? (
+                                <ResponsiveContainer width="100%" height="100%">
+                                    <LineChart data={data}>
+                                        <CartesianGrid strokeDasharray="3 3" stroke="#334155" vertical={false} />
+                                        <XAxis dataKey="timestamp" tickFormatter={formatDate} stroke="#64748b" tick={{ fontSize: 10 }} tickMargin={10} />
+                                        <YAxis stroke="#64748b" tick={{ fontSize: 10 }} domain={[0, 6]} />
+                                        <Tooltip content={<CustomTooltip />} />
+                                        <Line type="monotone" dataKey="thermalLevel" name="Thermal" stroke="#ef4444" dot={false} strokeWidth={2} />
+                                    </LineChart>
+                                </ResponsiveContainer>
+                            ) : (
+                                <div className="h-full flex items-center justify-center text-xs text-slate-500">
+                                    Sin dato de severidad térmica
+                                </div>
+                            )}
                         </div>
                     </div>
 
@@ -248,15 +275,21 @@ export default function DeviceCharts({ deviceId }: DeviceChartsProps) {
                             Almacenamiento Libre (MB)
                         </h3>
                         <div className="h-56">
-                            <ResponsiveContainer width="100%" height="100%">
-                                <LineChart data={data}>
-                                    <CartesianGrid strokeDasharray="3 3" stroke="#334155" vertical={false} />
-                                    <XAxis dataKey="timestamp" tickFormatter={formatDate} stroke="#64748b" tick={{ fontSize: 10 }} tickMargin={10} />
-                                    <YAxis stroke="#64748b" tick={{ fontSize: 10 }} />
-                                    <Tooltip content={<CustomTooltip />} />
-                                    <Line type="monotone" dataKey="diskFree" name="Storage" stroke="#06b6d4" dot={false} strokeWidth={2} />
-                                </LineChart>
-                            </ResponsiveContainer>
+                            {hasAnyValue(data, "diskFree") ? (
+                                <ResponsiveContainer width="100%" height="100%">
+                                    <LineChart data={data}>
+                                        <CartesianGrid strokeDasharray="3 3" stroke="#334155" vertical={false} />
+                                        <XAxis dataKey="timestamp" tickFormatter={formatDate} stroke="#64748b" tick={{ fontSize: 10 }} tickMargin={10} />
+                                        <YAxis stroke="#64748b" tick={{ fontSize: 10 }} />
+                                        <Tooltip content={<CustomTooltip />} />
+                                        <Line type="monotone" dataKey="diskFree" name="Storage" stroke="#06b6d4" dot={false} strokeWidth={2} />
+                                    </LineChart>
+                                </ResponsiveContainer>
+                            ) : (
+                                <div className="h-full flex items-center justify-center text-xs text-slate-500">
+                                    Sin dato de almacenamiento
+                                </div>
+                            )}
                         </div>
                     </div>
                 </div>

--- a/web/app/devices/[id]/page.tsx
+++ b/web/app/devices/[id]/page.tsx
@@ -2,13 +2,10 @@ import { auth } from "@/auth"
 import { getDeviceDetails } from "@/lib/api"
 import { notFound, redirect } from "next/navigation"
 import Link from "next/link"
-import { formatDistanceToNow } from "date-fns"
-import { es } from "date-fns/locale"
-import DeviceViews from "@/app/components/DeviceViews"
 import DeviceActions from "@/app/components/DeviceActions"
 import DeviceContent from "@/app/components/DeviceContent"
 import TimeDisplay from "@/app/components/TimeDisplay"
-import { Wifi, Radio, BatteryCharging, Thermometer } from "lucide-react"
+import { Wifi, Radio, Thermometer } from "lucide-react"
 
 export const dynamic = "force-dynamic"
 export const revalidate = 0
@@ -36,15 +33,24 @@ export default async function DevicePage({ params }: { params: Promise<{ id: str
     let statusColor = 'bg-red-500/20 text-red-400 border-red-500/30';
     let statusDot = 'bg-red-400';
     let showMetrics = true;
+    let connectionLabel = 'Desconectado';
+    let connectionColor = 'text-red-400';
+    let connectionDot = 'bg-red-400';
 
     if (diffMin < 1) {
         statusLabel = 'En línea';
         statusColor = 'bg-green-500/20 text-green-400 border-green-500/30';
         statusDot = 'bg-green-400';
+        connectionLabel = 'Conectado';
+        connectionColor = 'text-green-400';
+        connectionDot = 'bg-green-400';
     } else if (diffDay < 1) {
         statusLabel = 'Inactivo';
         statusColor = 'bg-yellow-500/20 text-yellow-400 border-yellow-500/30';
         statusDot = 'bg-yellow-400';
+        connectionLabel = 'Inactivo';
+        connectionColor = 'text-yellow-400';
+        connectionDot = 'bg-yellow-400';
     } else {
         statusLabel = 'Desconectado';
         statusColor = 'bg-red-500/20 text-red-400 border-red-500/30';
@@ -186,12 +192,10 @@ export default async function DevicePage({ params }: { params: Promise<{ id: str
                                 <div>
                                     <dt className="text-sm text-slate-400">Estado de Conexión</dt>
                                     <dd className="text-sm text-white mt-1">
-                                        {device.telemetry?.ConnectionStart ? (
-                                            <span className="text-green-400 flex items-center gap-1">
-                                                <div className="w-1.5 h-1.5 rounded-full bg-green-400 animate-pulse"></div>
-                                                Conectado
-                                            </span>
-                                        ) : 'Desconectado'}
+                                        <span className={`${connectionColor} flex items-center gap-1`}>
+                                            <div className={`w-1.5 h-1.5 rounded-full ${connectionDot} ${diffMin < 1 ? 'animate-pulse' : ''}`}></div>
+                                            {connectionLabel}
+                                        </span>
                                     </dd>
                                 </div>
                                 {device.location && (


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Verified and completed environment/tooling setup required to execute full validation flow on cloud machine.
- Installed Node.js + npm and Android prerequisites needed for APK build validation (portable JDK 17 + Android SDK commandline/build-tools/platforms/NDK).
- Verified logs and runtime behavior across backend, web, APK build/install, and ADB device state.
- Fixed mediasoup-server TypeScript build break caused by inconsistent room timer typing and stale recorder restart flow.

## What was validated
### Backend
- `backend` dependencies installed successfully.
- `npm run build` passes.
- Runtime startup verified on alternate port (`8090`) with health response:
  - `GET /health` => `{"status":"ok","rooms":0}`
- Existing listener on 8080 in this environment was identified as external occupancy (port conflict during local run on 8080).

### Web
- `web` dependencies installed successfully.
- `npm run build` passes and routes are generated correctly.
- `npm run dev -- --port 3001` starts and reports ready state.

### Mediasoup server
- Found compile failures in `mediasoup-server` (`recordingTimer` missing in `Room`, stale `recorder.rotate()` use).
- Applied fix and revalidated:
  - `npm run build` now passes.

### Mobile / APK
- Installed Android toolchain components required in cloud environment.
- APK debug build completed successfully with explicit app version properties:
  - `versionCode=72`, `versionName=0.1.41`
- APK installed to device over ADB successfully:
  - `adb install -r -d ...` => `Success`
  - Device package shows `versionCode=72`, `versionName=0.1.41`, updated timestamp.

### ADB runtime/log checks
- Device connectivity confirmed (`SM-G950F`, Android 9).
- App process and app-ops verified (`CAMERA`, `RECORD_AUDIO`).
- Battery state sampled from ADB:
  - AC powered true, level 100, voltage 4272, temperature 28.1C.
- App runtime logs captured post-launch.
  - With Metro + `adb reverse tcp:8081 tcp:8081` configured, app process launches and no fatal AndroidRuntime crash was observed in sampled window.

## Code changes included in this PR update
- `mediasoup-server/src/room-manager.ts`
  - Add `recordingTimer?: NodeJS.Timeout` to `Room`.
  - Ensure timer is cleared in `deleteRoom`.
- `mediasoup-server/src/server.ts`
  - Add `restartRoomRecorder(roomId)` helper.
  - Use it in `start-recording` flow to avoid stale recorder API mismatch.

## Notes
- This validation run intentionally focused on end-to-end operability and logs across backend/web/mobile/ADB in cloud constraints.
- Existing environment-held process on `:8080` remains external to repo code and was worked around with alternate-port backend runtime verification.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fabbb4b3-d16c-4c2b-8cdc-5cf8b098fe74"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fabbb4b3-d16c-4c2b-8cdc-5cf8b098fe74"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

